### PR TITLE
test(template): réajout d'un template de test

### DIFF
--- a/src/app/components/modal/modal.component.spec.ts
+++ b/src/app/components/modal/modal.component.spec.ts
@@ -1,0 +1,55 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalComponent } from './modal.component';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { MockTranslateLoader } from '../../models/MockTranslateLoader';
+import { LoaderComponent } from '../loader/loader.component';
+
+describe('ModalComponent', () => {
+  const component: ModalComponent;
+  const fixture: ComponentFixture<ModalComponent>;
+  const modalEl: DebugElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ModalComponent, LoaderComponent ],
+      imports: [
+        TranslateModule.forRoot({
+          loader: {provide: TranslateLoader, useClass: MockTranslateLoader},
+        })
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ModalComponent);
+    component = fixture.componentInstance;
+    modalEl = fixture.debugElement.query(By.css('div.gh-modal'));
+  });
+
+  it('tests the component creation', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('tests the visible property with true value', () => {
+    component.visible = true;
+    fixture.detectChanges();
+    const classList = modalEl.nativeElement.classList;
+    expect(classList).toContain('visible');
+  });
+
+  it('tests the visible property with false value', () => {
+    component.visible = false;
+    fixture.detectChanges();
+    const classList = modalEl.nativeElement.classList;
+    expect(classList.contains('visible')).toBeFalsy();
+  });
+
+  it('tests the openModal function', () => {
+    component.closeModal();
+    expect(component.visible).toBeFalsy();
+  });
+});

--- a/src/app/components/modal/modal.component.spec.ts
+++ b/src/app/components/modal/modal.component.spec.ts
@@ -8,9 +8,9 @@ import { MockTranslateLoader } from '../../models/MockTranslateLoader';
 import { LoaderComponent } from '../loader/loader.component';
 
 describe('ModalComponent', () => {
-  const component: ModalComponent;
-  const fixture: ComponentFixture<ModalComponent>;
-  const modalEl: DebugElement;
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+  let modalEl: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({


### PR DESCRIPTION
Julien Lamy avait supprimé le template de test pour la modal car il ne passait plus les tests après l'ajout du loader. Pour le moment il est nécessaire de le garder. Ainsi, je l'ai fix et remis en place. Le problème venait simplement du fait qu'il fallait déclarer dans le test le composant "LoaderComponent".