### PR TITLE
test(modal): Tests sur le composant modal

### DIFF
--- a/src/app/components/modal/modal.component.spec.ts
+++ b/src/app/components/modal/modal.component.spec.ts
@@ -58,8 +58,23 @@ describe('ModalComponent', () => {
     expect(ClassList.contains('visible')).toBeFalsy();
   });
 
-  it('tests the openModal function', () => {
+  it('tests the closeModal function with loading set as false', () => {
+    const Visible = false;
+    const Loading = false;
+    component.visible = Visible;
+    component.loading = Loading;
     component.closeModal();
     expect(component.visible).toBeFalsy();
+    expect(component.loading).toBeFalsy();
+  });
+
+  it('tests the closeModal function with loading set as true', () => {
+    const Visible = true;
+    const Loading = true;
+    component.visible = Visible;
+    component.loading = Loading;
+    component.closeModal();
+    expect(component.visible).toBeTruthy();
+    expect(component.visible).toBeTruthy();
   });
 });

--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -8,7 +8,7 @@ import { ThemePreferencesService } from '../../providers/theme-preferences.servi
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.scss']
 })
-export class ModalComponent implements OnInit {
+export class ModalComponent {
 
   @Input() large: Boolean;
   @Input() medium: Boolean;
@@ -40,9 +40,6 @@ export class ModalComponent implements OnInit {
     );
     this.themePrefService.emitThemePreferencesSubject();
    }
-
-  ngOnInit() {
-  }
 
   closeModal() {
     if (!this.loading) {


### PR DESCRIPTION
Ajout de deux tests avec coverage 100% pour la modal + retrait de la fonction ngOnInit() dans modal.component.ts