### PR TITLE
fix(button-bar): ajout d'un placeHolder dans la barre de recherche

### DIFF
--- a/src/app/screens/home/home.component.html
+++ b/src/app/screens/home/home.component.html
@@ -43,7 +43,8 @@
             <div class="col-4 gh-button-bar-more">
                 <div>
                     <div class="searchInput mr-3">
-                        <app-input [(value)]="commitHash" (keyup)="onKeyUp($event)" [disabled]="!repoName"></app-input>
+                        <app-input [(value)]="commitHash" (keyup)="onKeyUp($event)" [disabled]="!repoName"
+                        [placeholder]="'SEARCH_COMMIT'"></app-input>
                     </div>
                     <a class="cursor-pointer mr-3" placement="left" ngbTooltip="{{ 'SEARCH_COMMIT' | translate }}" 
                         (click)="setCommitHash()">


### PR DESCRIPTION
Ajout d'un placeHolder dans la barre de recherche, pas de changement sur les fichiers i18n car j'ai utilisé un mot clé déjà attribué au pop-up quand la loupe est survolée.
(issue #185)